### PR TITLE
Include the time for the FCP to end in final comment period comment.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U isort==5.7.0 flake8==3.8.4 flake8-comprehensions==3.3.1 black==20.8b1
+        pip install -U isort==5.7.0 flake8==3.8.4 flake8-comprehensions==3.3.1 black==22.3.0
 
     - name: Check import statement sorting
       run: |

--- a/command_handler.py
+++ b/command_handler.py
@@ -368,7 +368,8 @@ class CommandHandler(object):
         comment_text = (
             f":bell: This is now entering its final comment period, "
             f"as per [the review]({status_comment.html_url}) above. :bell:"
-            f"\n\nThe final comment period will end at {fcp_conclusion_time.isoformat()}."
+            f"\n\nThe final comment period will run for {self.config.fcp_time_days} "
+            f"days until {fcp_conclusion_time.isoformat()}."
         )
 
         # Post a comment stating that FCP has begun

--- a/command_handler.py
+++ b/command_handler.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import logging
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Tuple
 
 from github.IssueComment import IssueComment
@@ -356,7 +356,7 @@ class CommandHandler(object):
 
         # Calculate when this FCP should conclude
         fcp_conclusion_time = (
-            datetime.now()
+            datetime.now(timezone.utc)
             + timedelta(days=self.config.fcp_time_days)
             + timedelta(seconds=10)
         )
@@ -365,11 +365,12 @@ class CommandHandler(object):
         # Link to the status comment
         status_comment = self._get_status_comment()
 
+        # The conclusion time is formatted as July 14, 2022 at 14:34:14 UTC.
         comment_text = (
             f":bell: This is now entering its final comment period, "
             f"as per [the review]({status_comment.html_url}) above. :bell:"
             f"\n\nThe final comment period will run for {self.config.fcp_time_days} "
-            f"days until {fcp_conclusion_time.isoformat()}."
+            f"days until {fcp_conclusion_time.strftime('%B %-d, %Y at %H:%M:%S %Z')}."
         )
 
         # Post a comment stating that FCP has begun

--- a/command_handler.py
+++ b/command_handler.py
@@ -368,6 +368,7 @@ class CommandHandler(object):
         comment_text = (
             f":bell: This is now entering its final comment period, "
             f"as per [the review]({status_comment.html_url}) above. :bell:"
+            f"\n\nThe final comment period will end at {fcp_conclusion_time.isoformat()}."
         )
 
         # Post a comment stating that FCP has begun


### PR DESCRIPTION
Fixes #18

This just dumps it as ISO 8601 format, which isn't very human friendly. Suggestions of how you would like it to be formatted are appreciated!