### PR TITLE
Add matrix-org/spec-core-team as a universal codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @matrix-org/spec-core-team


### PR DESCRIPTION
This will enable automatic review request of @matrix-org/spec-core-team for any incoming pull requests.